### PR TITLE
feat: only install missing additional_components

### DIFF
--- a/check-modules.sh
+++ b/check-modules.sh
@@ -31,18 +31,18 @@ IFS=',' read -r -a CURRENTLY_INSTALLED <<< "$CURRENTLY_INSTALLED"
 IFS=',' read -r -a PROPOSED_COMPONENTS_TO_INSTALL <<< "$PROPOSED_COMPONENTS_TO_INSTALL"
 
 #get diff btw components already installed and those that need to be installed
-FINAL_COMPONENT_LIST=""
+FINAL_COMPONENT_LIST=()
 for component in "${PROPOSED_COMPONENTS_TO_INSTALL[@]}"
 do
     if [[ ! ${CURRENTLY_INSTALLED[*]} =~ $component ]]; then
-        FINAL_COMPONENT_LIST+="$component "
+        FINAL_COMPONENT_LIST+=("$component")
     fi
 done
 
 # if there is any component in list, install
-if [[ $FINAL_COMPONENT_LIST ]]; then
-    echo "Installing components $FINAL_COMPONENT_LIST";
-    $GCLOUD_PATH components install "${FINAL_COMPONENT_LIST}" --quiet
+if [[ ${FINAL_COMPONENT_LIST[*]} ]]; then
+    echo "Installing components ${FINAL_COMPONENT_LIST[*]}";
+    $GCLOUD_PATH components install "${FINAL_COMPONENT_LIST[@]}" --quiet
 else
-    echo "All components already installed."
+    echo "All components ${PROPOSED_COMPONENTS_TO_INSTALL[*]} already installed."
 fi

--- a/check-modules.sh
+++ b/check-modules.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [ "$#" -lt 2 ]; then
+    >&2 echo "Not all expected arguments set."
+    exit 1
+fi
+
+GCLOUD_PATH=$1
+PROPOSED_COMPONENTS_TO_INSTALL=$2
+
+# get list of currently installed components
+CURRENTLY_INSTALLED=$($GCLOUD_PATH components list --quiet --format json 2> /dev/null | jq -r '[.[] | select(.state.name!="Not Installed") | .id] | @tsv | gsub("\\t";",")')
+
+# transform to arrays
+IFS=',' read -r -a CURRENTLY_INSTALLED <<< "$CURRENTLY_INSTALLED"
+IFS=',' read -r -a PROPOSED_COMPONENTS_TO_INSTALL <<< "$PROPOSED_COMPONENTS_TO_INSTALL"
+
+#get diff btw components already installed and those that need to be installed
+FINAL_COMPONENT_LIST=""
+for component in "${PROPOSED_COMPONENTS_TO_INSTALL[@]}"
+do
+    if [[ ! ${CURRENTLY_INSTALLED[*]} =~ $component ]]; then
+        FINAL_COMPONENT_LIST+="$component "
+    fi
+done
+
+# if there is any component in list, install
+if [[ $FINAL_COMPONENT_LIST ]]; then
+    echo "Installing components $FINAL_COMPONENT_LIST";
+    $GCLOUD_PATH components install "${FINAL_COMPONENT_LIST}" --quiet
+else
+    echo "All components already installed."
+fi

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ locals {
   gcloud_tar_path      = "${local.cache_path}/google-cloud-sdk.tar.gz"
   gcloud_bin_path      = "${local.cache_path}/google-cloud-sdk/bin"
   gcloud_bin_abs_path  = abspath(local.gcloud_bin_path)
-  components           = join(" ", var.additional_components)
+  components           = join(",", var.additional_components)
 
   gcloud              = var.skip_download ? "gcloud" : "${local.gcloud_bin_path}/gcloud"
   gcloud_download_url = var.gcloud_download_url != "" ? var.gcloud_download_url : "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${var.gcloud_sdk_version}-${var.platform}-x86_64.tar.gz"
@@ -40,7 +40,7 @@ locals {
   download_jq_command                          = "curl -sL -o ${local.cache_path}/jq ${local.jq_download_url} && chmod +x ${local.cache_path}/jq"
   decompress_command                           = "tar -xzf ${local.gcloud_tar_path} -C ${local.cache_path} && cp ${local.cache_path}/jq ${local.cache_path}/google-cloud-sdk/bin/"
   upgrade_command                              = "${local.gcloud} components update --quiet"
-  additional_components_command                = "${local.gcloud} components install ${local.components} --quiet"
+  additional_components_command                = "${path.module}/check-modules.sh ${local.gcloud} ${local.components}"
   gcloud_auth_service_account_key_file_command = "${local.gcloud} auth activate-service-account --key-file ${var.service_account_key_file}"
   gcloud_auth_google_credentials_command       = <<-EOT
     printf "%s" "$GOOGLE_CREDENTIALS" > ${local.tmp_credentials_path} &&


### PR DESCRIPTION
fixes #52 

- Uses `external` [data source](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/data_source) to get a list of already installed components
- Added workaround to prevent `count value depends on resource attributes that cannot be determined until apply` error

TODO:

- [ ] testing with gke submodules on cloudshell