### PR TITLE
fix: Check for binaries in additional_components

### DIFF
--- a/check_components.sh
+++ b/check_components.sh
@@ -31,15 +31,29 @@ IFS=',' read -r -a CURRENTLY_INSTALLED <<< "$CURRENTLY_INSTALLED"
 IFS=',' read -r -a PROPOSED_COMPONENTS_TO_INSTALL <<< "$PROPOSED_COMPONENTS_TO_INSTALL"
 
 #get diff btw components already installed and those that need to be installed
-FINAL_COMPONENT_LIST=()
+FILTER_COMPONENT_LIST=()
 for component in "${PROPOSED_COMPONENTS_TO_INSTALL[@]}"
 do
     if [[ ! ${CURRENTLY_INSTALLED[*]} =~ $component ]]; then
+        FILTER_COMPONENT_LIST+=("$component")
+    else
+        echo "Found $component via gcloud component manager";
+    fi
+done
+
+# check if any component exists as a binary
+FINAL_COMPONENT_LIST=()
+for component in "${FILTER_COMPONENT_LIST[@]}"
+do
+    if [[ $(command -v "$component") ]]; then
+        echo "Found $component via $(command -v "$component")";
+    else
         FINAL_COMPONENT_LIST+=("$component")
     fi
 done
 
-# if there is any component in list, install
+
+# if there is any component left in list, install via gcloud
 if [[ ${FINAL_COMPONENT_LIST[*]} ]]; then
     echo "Installing components ${FINAL_COMPONENT_LIST[*]}";
     $GCLOUD_PATH components install "${FINAL_COMPONENT_LIST[@]}" --quiet

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ locals {
   download_jq_command                          = "curl -sL -o ${local.cache_path}/jq ${local.jq_download_url} && chmod +x ${local.cache_path}/jq"
   decompress_command                           = "tar -xzf ${local.gcloud_tar_path} -C ${local.cache_path} && cp ${local.cache_path}/jq ${local.cache_path}/google-cloud-sdk/bin/"
   upgrade_command                              = "${local.gcloud} components update --quiet"
-  additional_components_command                = "${path.module}/check-modules.sh ${local.gcloud} ${local.components}"
+  additional_components_command                = "${path.module}/check_components.sh ${local.gcloud} ${local.components}"
   gcloud_auth_service_account_key_file_command = "${local.gcloud} auth activate-service-account --key-file ${var.service_account_key_file}"
   gcloud_auth_google_credentials_command       = <<-EOT
     printf "%s" "$GOOGLE_CREDENTIALS" > ${local.tmp_credentials_path} &&

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,13 +16,14 @@
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 3.0"
+  version = "~> 8.0"
 
-  name              = "ci-gcloud"
-  random_project_id = "true"
-  org_id            = var.org_id
-  folder_id         = var.folder_id
-  billing_account   = var.billing_account
+  name                 = "ci-gcloud"
+  random_project_id    = "true"
+  org_id               = var.org_id
+  folder_id            = var.folder_id
+  billing_account      = var.billing_account
+  skip_gcloud_download = true
 
   activate_apis = [
     "cloudresourcemanager.googleapis.com",

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,9 +19,9 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.13.0"
+  version = "~> 3.30.0"
 }
 
 provider "google-beta" {
-  version = "~> 2.13.0"
+  version = "~> 3.30.0"
 }


### PR DESCRIPTION
fixes #56 
- Rather than removing the` gcloud components list ` as proposed here https://github.com/terraform-google-modules/terraform-google-gcloud/issues/56#issue-657732722 I am doing an additional filter with ` command -v $BINARY`. This is to account for scenarios where gcloud specific components like `beta`, `alpha` etc may have been pre installed.