### PR TITLE
fix: Add debug options and bump arg num check kubectl wrapper

### DIFF
--- a/modules/kubectl-wrapper/scripts/kubectl_wrapper.sh
+++ b/modules/kubectl-wrapper/scripts/kubectl_wrapper.sh
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 
-set -e
+set -xeo pipefail
 
-if [ "$#" -lt 3 ]; then
+if [ "$#" -lt 5 ]; then
     >&2 echo "Not all expected arguments set."
     exit 1
 fi


### PR DESCRIPTION
The arg number check does not match the `shift` number in the script which leads to confusing user failures.
Also we can fail faster and log more verbosely to help others debug similar situations easier in the future.
context:
https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/666#issuecomment-691351884