### PR TITLE
POSIX compliance - to make it work on NixOS and BSD

### DIFF
--- a/examples/dependency_example/scripts/script.sh
+++ b/examples/dependency_example/scripts/script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/sh
 
 for i in {1..5}
 do

--- a/examples/dependency_example/scripts/script.sh
+++ b/examples/dependency_example/scripts/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/script_example/scripts/script.sh
+++ b/examples/script_example/scripts/script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/sh
 
 GCLOUD_LOCATION=$(command -v gcloud)
 echo "Using gcloud from $GCLOUD_LOCATION"

--- a/modules/kubectl-wrapper/scripts/kubectl_wrapper.sh
+++ b/modules/kubectl-wrapper/scripts/kubectl_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/check_components.sh
+++ b/scripts/check_components.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Good day,

Not all Linux systems had `/bin/bash` which breaks this TF module. For example - NixOS. The same is for BSD systems I was told.

I hope you'll consider this PR.