### PR TITLE
feat: add option to skip sa activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Setting it to `never` will *never* gcloud download and setting it to `always` wi
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| activate\_service\_account | Set to false to skip running `gcloud auth activate-service-account`. Optional. | `bool` | `true` | no |
 | additional\_components | Additional gcloud CLI components to install. Defaults to none. Valid value are components listed in `gcloud components list` | `list(string)` | `[]` | no |
 | create\_cmd\_body | On create, the command body you'd like to run with your entrypoint. | `string` | `"info"` | no |
 | create\_cmd\_entrypoint | On create, the command entrypoint you'd like to use. Can also be set to a custom script. Module's bin directory will be prepended to path. | `string` | `"gcloud"` | no |

--- a/main.tf
+++ b/main.tf
@@ -46,9 +46,10 @@ locals {
   upgrade_command                              = "${local.gcloud} components update --quiet"
   additional_components_command                = "${path.module}/scripts/check_components.sh ${local.gcloud} ${local.components}"
   gcloud_auth_service_account_key_file_command = "${local.gcloud} auth activate-service-account --key-file ${var.service_account_key_file}"
+  activate_service_account                     = var.activate_service_account ? "${local.gcloud} auth activate-service-account --key-file ${local.tmp_credentials_path}" : "true"
   gcloud_auth_google_credentials_command       = <<-EOT
-    printf "%s" "$GOOGLE_CREDENTIALS" > ${local.tmp_credentials_path} &&
-    ${local.gcloud} auth activate-service-account --key-file ${local.tmp_credentials_path}
+    printf "%s" "$GOOGLE_CREDENTIALS" > ${local.tmp_credentials_path} && \
+    ${local.activate_service_account}
   EOT
 
 }

--- a/variables.tf
+++ b/variables.tf
@@ -92,6 +92,12 @@ variable "use_tf_google_credentials_env_var" {
   default     = false
 }
 
+variable "activate_service_account" {
+  description = "Set to false to skip running `gcloud auth activate-service-account`. Optional."
+  type        = bool
+  default     = true
+}
+
 variable "jq_version" {
   description = "The jq version to download."
   type        = string


### PR DESCRIPTION
This allows using other types of keys, specifically the ADC. 

My use case is as follows:

- I'm using this module to init a gcp project which means there is no service account yet. 
- I'm running terraform in a docker container and have already authenticated my personal user account using `gcloud login` on the host.
- I'm mounting the ADC from above onto the terraform container 

I think previously it was recommended to not use ADC for terraform but that is no longer the case. The first thing on the provider docs is:

> If you are using Terraform on your workstation we recommend that you install gcloud and authenticate using [User Application Default Credentials ("ADCs")](https://cloud.google.com/sdk/gcloud/reference/auth/application-default) as a primary authentication method. You can enable ADCs by running the command gcloud auth application-default login.

Not sure if there are other better options for using ADC, but it does seem to get the job done for me