### PR TITLE
fix(kubectl-wrapper): fix positional argument shifting with impersona…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ crash.log
 google-cloud-sdk/
 google-cloud-sdk.staging/
 credentials.json
+terraform-google-credentials.json
 tmp
 
 # Ignore cache directory

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ You can also override the behavior by setting the `GCLOUD_TF_DOWNLOAD` environme
 This environment variable will override all other settings.
 Setting it to `never` will *never* gcloud download and setting it to `always` will always download gcloud.
 
+> **Note on Service Account Authentication (gcloud 575.0.0+):** Starting in Google Cloud CLI 575.0.0+, `gcloud config config-helper` (invoked by tools like `kubectl` via `gke-gcloud-auth-plugin`) requires an explicitly authenticated service account key file context. To ensure commands function properly with `gcloud 575.0.0+`, set `use_tf_google_credentials_env_var = true` or provide `service_account_key_file` so `gcloud auth activate-service-account` is executed for the `gcloud` instance.
+
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 

--- a/examples/kubectl_wrapper_example/main.tf
+++ b/examples/kubectl_wrapper_example/main.tf
@@ -98,13 +98,14 @@ module "kubectl-local-yaml" {
   source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
   version = "~> 4.0"
 
-  project_id              = var.project_id
-  cluster_name            = module.gke.name
-  cluster_location        = module.gke.location
-  module_depends_on       = [module.kubectl-imperative.wait, module.gke.endpoint]
-  kubectl_create_command  = "kubectl apply -f ${local.manifest_path}/nginx.yaml"
-  kubectl_destroy_command = "kubectl delete -f ${local.manifest_path}/nginx.yaml"
-  skip_download           = false
+  project_id                         = var.project_id
+  cluster_name                       = module.gke.name
+  cluster_location                   = module.gke.location
+  module_depends_on                  = [module.kubectl-imperative.wait, module.gke.endpoint]
+  kubectl_create_command             = "kubectl apply -f ${local.manifest_path}/nginx.yaml"
+  kubectl_destroy_command            = "kubectl delete -f ${local.manifest_path}/nginx.yaml"
+  skip_download                      = false
+  use_tf_google_credentials_env_var = true
 }
 
 module "fleet" {
@@ -122,13 +123,14 @@ module "kubectl-fleet-imperative" {
   source  = "terraform-google-modules/gcloud/google//modules/kubectl-fleet-wrapper"
   version = "~> 4.0"
 
-  membership_name         = module.fleet.cluster_membership_id
-  membership_project_id   = module.fleet.project_id
-  membership_location     = module.fleet.location
-  module_depends_on       = [module.kubectl-local-yaml.wait, module.fleet.wait]
-  kubectl_create_command  = "kubectl run nginx-fleet-imperative --image=nginx"
-  kubectl_destroy_command = "kubectl delete pod nginx-fleet-imperative"
-  skip_download           = false
+  membership_name                    = module.fleet.cluster_membership_id
+  membership_project_id              = module.fleet.project_id
+  membership_location                = module.fleet.location
+  module_depends_on                  = [module.kubectl-local-yaml.wait, module.fleet.wait]
+  kubectl_create_command             = "kubectl run nginx-fleet-imperative --image=nginx"
+  kubectl_destroy_command            = "kubectl delete pod nginx-fleet-imperative"
+  skip_download                      = false
+  use_tf_google_credentials_env_var = true
 }
 
 module "kubectl-fleet-local-yaml" {
@@ -142,4 +144,33 @@ module "kubectl-fleet-local-yaml" {
   kubectl_create_command  = "kubectl apply -f ${local.manifest_path}/nginx-fleet.yaml"
   kubectl_destroy_command = "kubectl delete -f ${local.manifest_path}/nginx-fleet.yaml"
   skip_download           = true
+}
+
+module "kubectl-impersonate" {
+  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
+  version = "~> 4.0"
+
+  project_id                  = var.project_id
+  cluster_name                = module.gke.name
+  cluster_location            = module.gke.location
+  impersonate_service_account = module.gke.service_account
+  module_depends_on           = [module.kubectl-fleet-local-yaml.wait, module.gke.endpoint]
+  kubectl_create_command      = "kubectl run nginx-impersonate --image=nginx"
+  kubectl_destroy_command     = "kubectl delete pod nginx-impersonate"
+  skip_download               = true
+}
+
+module "kubectl-existing-context" {
+  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
+  version = "~> 4.0"
+
+  project_id                  = var.project_id
+  cluster_name                = module.gke.name
+  cluster_location            = module.gke.location
+  use_existing_context        = true
+  impersonate_service_account = module.gke.service_account
+  module_depends_on           = [module.kubectl-impersonate.wait, module.gke.endpoint]
+  kubectl_create_command      = "kubectl run nginx-existing-context --image=nginx"
+  kubectl_destroy_command     = "kubectl delete pod nginx-existing-context"
+  skip_download               = true
 }

--- a/modules/kubectl-fleet-wrapper/scripts/kubectl_fleet_wrapper.sh
+++ b/modules/kubectl-fleet-wrapper/scripts/kubectl_fleet_wrapper.sh
@@ -28,24 +28,22 @@ IMPERSONATE_SERVICE_ACCOUNT=$4
 
 shift 4
 
-RANDOM_ID="${RANDOM}_${RANDOM}"
-export TMPDIR="/tmp/kubectl_fleet_wrapper_${RANDOM_ID}"
+TMPDIR=$(mktemp -d -t kubectl_fleet_wrapper_XXXXXX)
+export TMPDIR
 
 function cleanup {
-    rm -rf "${TMPDIR}"
+    [[ -n "${TMPDIR}" && -d "${TMPDIR}" ]] && rm -rf "${TMPDIR}"
 }
 trap cleanup EXIT
 
-mkdir "${TMPDIR}"
-
 export KUBECONFIG="${TMPDIR}/config"
 
-CMD="gcloud container fleet memberships get-credentials ${NAME} --project ${PROJECT_ID} --location ${LOCATION}"
+CMD=(gcloud container fleet memberships get-credentials "${NAME}" --project "${PROJECT_ID}" --location "${LOCATION}")
 
-if [[ "${IMPERSONATE_SERVICE_ACCOUNT}" != false ]]; then
-  CMD+=" --impersonate-service-account ${IMPERSONATE_SERVICE_ACCOUNT}"
+if [[ "${IMPERSONATE_SERVICE_ACCOUNT}" != "false" && -n "${IMPERSONATE_SERVICE_ACCOUNT}" ]]; then
+  CMD+=(--impersonate-service-account "${IMPERSONATE_SERVICE_ACCOUNT}")
 fi
 
-$CMD
+"${CMD[@]}"
 
 "$@"

--- a/modules/kubectl-wrapper/README.md
+++ b/modules/kubectl-wrapper/README.md
@@ -20,6 +20,9 @@ module "kubectl" {
 }
 ```
 
+> **Note on Authentication (gcloud 575.0.0+):** Starting in Google Cloud CLI 575.0.0+, `gcloud config config-helper` (invoked by `kubectl` via `gke-gcloud-auth-plugin`) requires an explicitly authenticated service account key file context. When running commands with `gcloud 575.0.0+`, set `use_tf_google_credentials_env_var = true` (or supply `service_account_key_file`) so the `gcloud` instance is authenticated to run `gke-gcloud-auth-plugin`.
+
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 

--- a/modules/kubectl-wrapper/scripts/kubectl_wrapper.sh
+++ b/modules/kubectl-wrapper/scripts/kubectl_wrapper.sh
@@ -29,45 +29,51 @@ USE_EXISTING_CONTEXT=$5
 ENABLE_IMPERSONATE_SERVICE_ACCOUNT=$6
 IMPERSONATE_SERVICE_ACCOUNT=$7
 
-shift 5
+if [[ "${ENABLE_IMPERSONATE_SERVICE_ACCOUNT}" == "true" ]]; then
+    if [ "$#" -lt 7 ]; then
+        >&2 echo "Not all expected arguments set (expected at least 7)."
+        exit 1
+    fi
+    shift 7
+else
+    shift 5
+fi
 
-if $USE_EXISTING_CONTEXT ;then
+if [[ "${USE_EXISTING_CONTEXT}" == "true" ]]; then
 
     "$@"
 
 else
 
-    RANDOM_ID="${RANDOM}_${RANDOM}"
-    export TMPDIR="/tmp/kubectl_wrapper_${RANDOM_ID}"
+    TMPDIR=$(mktemp -d -t kubectl_wrapper_XXXXXX)
+    export TMPDIR
 
     function cleanup {
-        rm -rf "${TMPDIR}"
+        [[ -n "${TMPDIR}" && -d "${TMPDIR}" ]] && rm -rf "${TMPDIR}"
     }
     trap cleanup EXIT
 
-    mkdir "${TMPDIR}"
-
     export KUBECONFIG="${TMPDIR}/config"
 
-    LOCATION_TYPE=$(grep -o "-" <<< "${LOCATION}" | wc -l)
+    LOCATION_TYPE=$(grep -o "-" <<< "${LOCATION}" | wc -l || true)
 
-    CMD="gcloud container clusters get-credentials ${CLUSTER_NAME} --project ${PROJECT_ID}"
-    if [[ "${ENABLE_IMPERSONATE_SERVICE_ACCOUNT}" == true ]]; then
-      CMD+=" --impersonate-service-account ${IMPERSONATE_SERVICE_ACCOUNT}"
-      shift 2
+    CMD=(gcloud container clusters get-credentials "${CLUSTER_NAME}" --project "${PROJECT_ID}")
+
+    if [[ "${ENABLE_IMPERSONATE_SERVICE_ACCOUNT}" == "true" && -n "${IMPERSONATE_SERVICE_ACCOUNT}" ]]; then
+      CMD+=(--impersonate-service-account "${IMPERSONATE_SERVICE_ACCOUNT}")
     fi
 
-    if [[ $LOCATION_TYPE -eq 2 ]] ;then
-        CMD+=" --zone ${LOCATION}"
+    if [[ ${LOCATION_TYPE} -eq 2 ]]; then
+        CMD+=(--zone "${LOCATION}")
     else
-        CMD+=" --region ${LOCATION}"
+        CMD+=(--region "${LOCATION}")
     fi
 
-    if $INTERNAL ;then
-        CMD+=" --internal-ip"
+    if [[ "${INTERNAL}" == "true" ]]; then
+        CMD+=(--internal-ip)
     fi
 
-    $CMD
+    "${CMD[@]}"
 
     "$@"
 fi

--- a/test/integration/kubectl_wrapper_example/controls/kubectl.rb
+++ b/test/integration/kubectl_wrapper_example/controls/kubectl.rb
@@ -74,6 +74,22 @@ control "kubectl" do
 					expect(nginxi).not_to be_nil
 				end
 			end
+
+			describe "nginx-impersonate" do
+				let(:nginximp) { client.get_pod("nginx-impersonate", "default") }
+
+				it "exists" do
+					expect(nginximp).not_to be_nil
+				end
+			end
+
+			describe "nginx-existing-context" do
+				let(:nginxctx) { client.get_pod("nginx-existing-context", "default") }
+
+				it "exists" do
+					expect(nginxctx).not_to be_nil
+				end
+			end
 		end
 	end
 end


### PR DESCRIPTION
…tion and existing context

Fix positional argument mismatch in kubectl_wrapper.sh when use_existing_context = true is combined with service account impersonation. Shift logic now evaluates ENABLE_IMPERSONATE_SERVICE_ACCOUNT upfront before checking USE_EXISTING_CONTEXT, preventing execution drops.

Harden script execution in kubectl_wrapper.sh and kubectl_fleet_wrapper.sh:
- Use mktemp -d for atomic, 0700-permission temporary directory creation
- Use Bash arrays ("${CMD[@]}") for safe gcloud command execution
- Add pipefail protection on location parsing pipeline

Expand integration test fixtures and InSpec controls to verify service account impersonation and existing context pods.