### PR TITLE
feat(gcloud 575.0.0)!: update kubectl_wrapper_example and documentation for gcloud CLI 575.0.0+ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Setting it to `never` will *never* gcloud download and setting it to `always` wi
 | destroy\_cmd\_entrypoint | On destroy, the command entrypoint you'd like to use.  Can also be set to a custom script. Module's bin directory will be prepended to path. | `string` | `"gcloud"` | no |
 | enabled | Flag to optionally disable usage of this module. | `bool` | `true` | no |
 | gcloud\_download\_url | Custom gcloud download url. Optional. | `string` | `""` | no |
-| gcloud\_sdk\_version | The gcloud sdk version to download. | `string` | `"481.0.0"` | no |
+| gcloud\_sdk\_version | The gcloud sdk version to download. | `string` | `"575.0.0"` | no |
 | jq\_download\_url | Custom jq download url. Optional. | `string` | `""` | no |
 | jq\_version | The jq version to download. | `string` | `"1.6"` | no |
 | module\_depends\_on | List of modules or resources this module depends on. | `list(any)` | `[]` | no |

--- a/examples/kubectl_wrapper_example/README.md
+++ b/examples/kubectl_wrapper_example/README.md
@@ -2,6 +2,8 @@
 
 This example illustrates how to use the kubectl submodule to deploy Kubernetes resources.
 
+Note: For compatibility with gcloud CLI 575.0.0+, the `gke-gcloud-auth-plugin` component is included in `additional_components` alongside `kubectl`.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 

--- a/examples/kubectl_wrapper_example/main.tf
+++ b/examples/kubectl_wrapper_example/main.tf
@@ -91,6 +91,7 @@ module "kubectl-imperative" {
   module_depends_on       = [module.gke.endpoint]
   kubectl_create_command  = "kubectl run nginx-imperative --image=nginx"
   kubectl_destroy_command = "kubectl delete pod nginx-imperative"
+  additional_components   = ["kubectl", "gke-gcloud-auth-plugin"]
   skip_download           = true
 }
 
@@ -104,6 +105,7 @@ module "kubectl-local-yaml" {
   module_depends_on       = [module.kubectl-imperative.wait, module.gke.endpoint]
   kubectl_create_command  = "kubectl apply -f ${local.manifest_path}/nginx.yaml"
   kubectl_destroy_command = "kubectl delete -f ${local.manifest_path}/nginx.yaml"
+  additional_components   = ["kubectl", "gke-gcloud-auth-plugin"]
   skip_download           = false
 }
 
@@ -128,6 +130,7 @@ module "kubectl-fleet-imperative" {
   module_depends_on       = [module.kubectl-local-yaml.wait, module.fleet.wait]
   kubectl_create_command  = "kubectl run nginx-fleet-imperative --image=nginx"
   kubectl_destroy_command = "kubectl delete pod nginx-fleet-imperative"
+  additional_components   = ["kubectl", "gke-gcloud-auth-plugin"]
   skip_download           = false
 }
 
@@ -141,5 +144,6 @@ module "kubectl-fleet-local-yaml" {
   module_depends_on       = [module.kubectl-fleet-imperative.wait, module.gke.endpoint]
   kubectl_create_command  = "kubectl apply -f ${local.manifest_path}/nginx-fleet.yaml"
   kubectl_destroy_command = "kubectl delete -f ${local.manifest_path}/nginx-fleet.yaml"
+  additional_components   = ["kubectl", "gke-gcloud-auth-plugin"]
   skip_download           = true
 }

--- a/modules/kubectl-fleet-wrapper/README.md
+++ b/modules/kubectl-fleet-wrapper/README.md
@@ -25,10 +25,10 @@ module "kubectl" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| additional\_components | Additional gcloud CLI components to install. Valid value are components listed in `gcloud components list` | `list(string)` | <pre>[<br>  "kubectl"<br>]</pre> | no |
+| additional\_components | Additional gcloud CLI components to install. Defaults to installing kubectl and gke-gcloud-auth-plugin. Valid value are components listed in `gcloud components list` | `list(string)` | <pre>[<br>  "kubectl",<br>  "gke-gcloud-auth-plugin"<br>]</pre> | no |
 | create\_cmd\_triggers | List of any additional triggers for the create command execution. | `map(any)` | `{}` | no |
 | enabled | Flag to optionally disable usage of this module. | `bool` | `true` | no |
-| gcloud\_sdk\_version | The gcloud sdk version to download. | `string` | `"481.0.0"` | no |
+| gcloud\_sdk\_version | The gcloud sdk version to download. | `string` | `"575.0.0"` | no |
 | impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `null` | no |
 | kubectl\_create\_command | The kubectl command to create resources. | `string` | n/a | yes |
 | kubectl\_destroy\_command | The kubectl command to destroy resources. | `string` | n/a | yes |

--- a/modules/kubectl-fleet-wrapper/variables.tf
+++ b/modules/kubectl-fleet-wrapper/variables.tf
@@ -58,9 +58,9 @@ variable "create_cmd_triggers" {
 }
 
 variable "additional_components" {
-  description = "Additional gcloud CLI components to install. Valid value are components listed in `gcloud components list`"
+  description = "Additional gcloud CLI components to install. Defaults to installing kubectl and gke-gcloud-auth-plugin. Valid value are components listed in `gcloud components list`"
   type        = list(string)
-  default     = ["kubectl"]
+  default     = ["kubectl", "gke-gcloud-auth-plugin"]
 }
 
 variable "skip_download" {
@@ -72,7 +72,7 @@ variable "skip_download" {
 variable "gcloud_sdk_version" {
   description = "The gcloud sdk version to download."
   type        = string
-  default     = "481.0.0"
+  default     = "575.0.0"
 }
 
 variable "upgrade" {

--- a/modules/kubectl-wrapper/README.md
+++ b/modules/kubectl-wrapper/README.md
@@ -25,12 +25,12 @@ module "kubectl" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| additional\_components | Additional gcloud CLI components to install. Defaults to installing kubectl. Valid value are components listed in `gcloud components list` | `list(string)` | <pre>[<br>  "kubectl"<br>]</pre> | no |
+| additional\_components | Additional gcloud CLI components to install. Defaults to installing kubectl and gke-gcloud-auth-plugin. Valid value are components listed in `gcloud components list` | `list(string)` | <pre>[<br>  "kubectl",<br>  "gke-gcloud-auth-plugin"<br>]</pre> | no |
 | cluster\_location | Cluster location (Zone/Region). Optional if use\_existing\_context is true. | `string` | `""` | no |
 | cluster\_name | Cluster name. Optional if use\_existing\_context is true. | `string` | `""` | no |
 | create\_cmd\_triggers | List of any additional triggers for the create command execution. | `map(any)` | `{}` | no |
 | enabled | Flag to optionally disable usage of this module. | `bool` | `true` | no |
-| gcloud\_sdk\_version | The gcloud sdk version to download. | `string` | `"481.0.0"` | no |
+| gcloud\_sdk\_version | The gcloud sdk version to download. | `string` | `"575.0.0"` | no |
 | impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
 | internal\_ip | Use internal ip for the cluster endpoint. | `bool` | `false` | no |
 | kubectl\_create\_command | The kubectl command to create resources. | `string` | n/a | yes |

--- a/modules/kubectl-wrapper/variables.tf
+++ b/modules/kubectl-wrapper/variables.tf
@@ -61,9 +61,9 @@ variable "create_cmd_triggers" {
 }
 
 variable "additional_components" {
-  description = "Additional gcloud CLI components to install. Defaults to installing kubectl. Valid value are components listed in `gcloud components list`"
+  description = "Additional gcloud CLI components to install. Defaults to installing kubectl and gke-gcloud-auth-plugin. Valid value are components listed in `gcloud components list`"
   type        = list(string)
-  default     = ["kubectl"]
+  default     = ["kubectl", "gke-gcloud-auth-plugin"]
 }
 
 variable "skip_download" {
@@ -75,7 +75,7 @@ variable "skip_download" {
 variable "gcloud_sdk_version" {
   description = "The gcloud sdk version to download."
   type        = string
-  default     = "481.0.0"
+  default     = "575.0.0"
 }
 
 variable "upgrade" {

--- a/scripts/check_components.sh
+++ b/scripts/check_components.sh
@@ -43,13 +43,26 @@ do
 done
 
 # check if any component exists as a binary
+GCLOUD_BIN_DIR=""
+if [[ "$GCLOUD_PATH" == *"/"* ]]; then
+    GCLOUD_BIN_DIR=$(dirname "$GCLOUD_PATH")
+fi
+
 FINAL_COMPONENT_LIST=()
 for component in "${FILTER_COMPONENT_LIST[@]}"
 do
-    if [[ $(command -v "$component") ]]; then
-        echo "Found $component via $(command -v "$component")";
+    if [[ -n "$GCLOUD_BIN_DIR" ]]; then
+        if [[ -x "$GCLOUD_BIN_DIR/$component" ]]; then
+            echo "Found $component via $GCLOUD_BIN_DIR/$component";
+        else
+            FINAL_COMPONENT_LIST+=("$component")
+        fi
     else
-        FINAL_COMPONENT_LIST+=("$component")
+        if [[ $(command -v "$component") ]]; then
+            echo "Found $component via $(command -v "$component")";
+        else
+            FINAL_COMPONENT_LIST+=("$component")
+        fi
     fi
 done
 

--- a/variables.tf
+++ b/variables.tf
@@ -107,7 +107,7 @@ variable "jq_version" {
 variable "gcloud_sdk_version" {
   description = "The gcloud sdk version to download."
   type        = string
-  default     = "481.0.0"
+  default     = "575.0.0"
 }
 
 variable "gcloud_download_url" {


### PR DESCRIPTION
Update default gcloud_sdk_version to 575.0.0 and include gke-gcloud-auth-plugin in additional_components for kubectl-wrapper and kubectl-fleet-wrapper modules and example configs to ensure gcloud CLI 575.0.0+ compatibility.