### PR TITLE
fix(ci): enable ADC for gke-gcloud-auth-plugin, bump dev-tools to 1.28, and right-size test GKE cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash -O extglob
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.26
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.28
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -29,7 +29,7 @@ steps:
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do create default']
 - id: converge
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && (kitchen_do converge default || (echo "Retrying converge default after transient error..." && sleep 30 && kitchen_do converge default))']
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && (kitchen_do converge default']
 - id: verify
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify default']
@@ -43,7 +43,7 @@ steps:
   - 'GCLOUD_TF_DOWNLOAD=never'
 - id: converge-skipped
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && (kitchen_do converge skipped-env || (echo "Retrying converge skipped-env after transient error..." && sleep 30 && kitchen_do converge skipped-env))']
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && (kitchen_do converge skipped-env']
   env:
     - 'GCLOUD_TF_DOWNLOAD=never'
 - id: verify-skipped

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-timeout: 3600s
+timeout: 5400s
 steps:
 - id: swap-module-refs
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
@@ -29,7 +29,7 @@ steps:
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do create default']
 - id: converge
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge default']
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && (kitchen_do converge default || (echo "Retrying converge default after transient error..." && sleep 30 && kitchen_do converge default))']
 - id: verify
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify default']
@@ -43,7 +43,7 @@ steps:
   - 'GCLOUD_TF_DOWNLOAD=never'
 - id: converge-skipped
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge skipped-env']
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && (kitchen_do converge skipped-env || (echo "Retrying converge skipped-env after transient error..." && sleep 30 && kitchen_do converge skipped-env))']
   env:
     - 'GCLOUD_TF_DOWNLOAD=never'
 - id: verify-skipped
@@ -61,4 +61,7 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.26'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.28'
+options:
+  env:
+  - 'CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -29,7 +29,7 @@ steps:
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do create default']
 - id: converge
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && (kitchen_do converge default']
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge default']
 - id: verify
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do verify default']
@@ -43,7 +43,7 @@ steps:
   - 'GCLOUD_TF_DOWNLOAD=never'
 - id: converge-skipped
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && (kitchen_do converge skipped-env']
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && kitchen_do converge skipped-env']
   env:
     - 'GCLOUD_TF_DOWNLOAD=never'
 - id: verify-skipped

--- a/examples/kubectl_wrapper_example/main.tf
+++ b/examples/kubectl_wrapper_example/main.tf
@@ -68,8 +68,9 @@ module "gke" {
   version                = "~> 44.0"
   project_id             = module.enabled_google_apis.project_id
   name                   = var.cluster_name
-  regional               = true
+  regional               = false
   region                 = var.region
+  zones                  = ["${var.region}-a"]
   network                = module.gcp-network.network_name
   subnetwork             = module.gcp-network.subnets_names[0]
   ip_range_pods          = var.ip_range_pods_name


### PR DESCRIPTION
### Summary
- **Fix `gcloud 573.0.0+` crash in `gke-gcloud-auth-plugin` (b/525047270)**: Set `CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true` in `build/int.cloudbuild.yaml` (`options.env`). This causes `gcloud container clusters/fleet memberships get-credentials` in CI to pass `--use_application_default_credentials` to `gke-gcloud-auth-plugin`, preventing it from invoking `gcloud config config-helper --format=json` (which crashes on Google Cloud SDK >= 573.0.0 under GCE metadata credentials).
- **Bump `cft/developer-tools` to `1.28`**: Update `build/int.cloudbuild.yaml` and `Makefile`.
- **Fix GCE stockout failures in `us-central1`**: Switch the GKE cluster in `examples/kubectl_wrapper_example/main.tf` from a multi-zone regional cluster (`regional = true`) to a single-zone zonal cluster (`regional = false`, `zones = ["${var.region}-a"]`).
- **Fix Cloud Build `EXPIRED` queue timeouts & transient API errors**: Increase `timeout` in `build/int.cloudbuild.yaml` from `3600s` to `5400s`